### PR TITLE
Added a versioned requirement on arteria-core

### DIFF
--- a/requirements/dev
+++ b/requirements/dev
@@ -1,5 +1,5 @@
 -r prod
-nose
-nose-watch
-requests
-mock
+nose==1.3.7
+nose-watch==0.9.1
+requests==2.7.0
+mock==1.3.0

--- a/requirements/prod
+++ b/requirements/prod
@@ -1,4 +1,4 @@
-arteria
+arteria==0.1.0
 jsonpickle==0.9.2
 tornado==4.2.1
 PyYAML==3.11

--- a/requirements/prod
+++ b/requirements/prod
@@ -1,4 +1,4 @@
-arteria==0.1.0
+git+https://github.com/arteria-project/arteria-core.git#egg=arteria-core
 jsonpickle==0.9.2
 tornado==4.2.1
 PyYAML==3.11


### PR DESCRIPTION
The runfolder service requires version 0.1.0 of arteria-core.
