### PR TITLE
Quarantine runfolders after pickup

### DIFF
--- a/requirements/prod
+++ b/requirements/prod
@@ -1,4 +1,4 @@
-git+https://github.com/arteria-project/arteria-core.git@v1.0.2#egg=arteria-core
+git+https://github.com/arteria-project/arteria-core.git@v1.1.0#egg=arteria-core
 jsonpickle==0.9.2
 tornado==4.2.1
 PyYAML==3.11

--- a/requirements/prod
+++ b/requirements/prod
@@ -1,4 +1,4 @@
-git+https://github.com/arteria-project/arteria-core.git@v1.0.1#egg=arteria-core
+git+https://github.com/arteria-project/arteria-core.git@v1.0.2#egg=arteria-core
 jsonpickle==0.9.2
 tornado==4.2.1
 PyYAML==3.11

--- a/runfolder/app.py
+++ b/runfolder/app.py
@@ -13,6 +13,7 @@ def start():
     routes = [
         (r"/api/1.0/runfolders", ListAvailableRunfoldersHandler, args),
         (r"/api/1.0/runfolders/next", NextAvailableRunfolderHandler, args),
+        (r"/api/1.0/runfolders/pickup", PickupAvailableRunfolderHandler, args),
         (r"/api/1.0/runfolders/path(/.*)", RunfolderHandler, args),
         (r"/api/1.0/runfolders/test/markasready/path(/.*)", TestFakeSequencerReadyHandler, args)
     ]

--- a/runfolder/handlers.py
+++ b/runfolder/handlers.py
@@ -1,7 +1,12 @@
+
+import tornado.web
+
+
 import arteria
+from arteria.web.state import State
 from arteria.web.handlers import BaseRestHandler
 from runfolder.services import *
-import tornado.web
+
 
 
 class BaseRunfolderHandler(BaseRestHandler):
@@ -40,7 +45,7 @@ class ListAvailableRunfoldersHandler(BaseRunfolderHandler):
         def get_runfolders():
             try:
                 # TODO: This list should be paged. The unfiltered list can be large
-                state = self.get_argument("state", RunfolderState.READY)
+                state = self.get_argument("state", State.READY)
                 if state == "*":
                     state = None
                 for runfolder_info in self.runfolder_svc.list_runfolders(state):
@@ -74,8 +79,8 @@ class PickupAvailableRunfolderHandler(BaseRunfolderHandler):
         runfolder_info = self.runfolder_svc.next_runfolder()
         if runfolder_info:
             self.append_runfolder_link(runfolder_info)
-            self.runfolder_svc.set_runfolder_state(runfolder_info.path, RunfolderState.PENDING)
-            runfolder_info.state = RunfolderState.PENDING
+            self.runfolder_svc.set_runfolder_state(runfolder_info.path, State.PENDING)
+            runfolder_info.state = State.PENDING
             self.write_object(runfolder_info)
         else:
             self.write(dict())

--- a/runfolder/handlers.py
+++ b/runfolder/handlers.py
@@ -1,14 +1,12 @@
 
 import tornado.web
 
-
 import arteria
 from arteria.web.state import State
 from arteria.exceptions import InvalidArteriaStateException
 from arteria.web.handlers import BaseRestHandler
+
 from runfolder.services import *
-
-
 
 class BaseRunfolderHandler(BaseRestHandler):
     """Provides core logic for all runfolder handlers"""
@@ -62,7 +60,7 @@ class NextAvailableRunfolderHandler(BaseRunfolderHandler):
     """Handles fetching the next available runfolder"""
     def get(self):
         """
-        Returns the next runfolder to process. Note that will not lock the runfolder, and unless it's
+        Returns the next runfolder to process. Note that it will not lock the runfolder, and unless its
         state is changed by the polling client quickly enough it will be presented again.
         """
         runfolder_info = self.runfolder_svc.next_runfolder()

--- a/runfolder/handlers.py
+++ b/runfolder/handlers.py
@@ -82,6 +82,7 @@ class PickupAvailableRunfolderHandler(BaseRunfolderHandler):
             runfolder_info.state = State.PENDING
             self.write_object(runfolder_info)
         else:
+            self.set_status(204, reason="No ready runfolders available.")
             self.write(dict())
 
 

--- a/runfolder/handlers.py
+++ b/runfolder/handlers.py
@@ -4,6 +4,7 @@ import tornado.web
 
 import arteria
 from arteria.web.state import State
+from arteria.exceptions import InvalidArteriaStateException
 from arteria.web.handlers import BaseRestHandler
 from runfolder.services import *
 
@@ -117,7 +118,7 @@ class RunfolderHandler(BaseRunfolderHandler):
 
         try:
             self.runfolder_svc.set_runfolder_state(path, state)
-        except InvalidRunfolderState:
+        except InvalidArteriaStateException:
             raise tornado.web.HTTPError(400, "The state '{}' is not valid".format(state))
 
     @arteria.undocumented

--- a/runfolder/services.py
+++ b/runfolder/services.py
@@ -28,11 +28,13 @@ class Enum(set):
 """
 NONE: Not ready for processing or invalid
 READY: Ready for processing
+PENDING: This runfolder has been handed to some other service, and is awaiting having it's status set.
+         It will wait X number of minutes before becoming available again.
 STARTED: Started processing the runfolder
 DONE: Done processing the runfolder
 ERROR: Started processing the runfolder but there was an error
 """
-RunfolderState = Enum(["NONE", "READY", "STARTED", "DONE", "ERROR"])
+RunfolderState = Enum(["NONE", "READY", "PENDING", "STARTED", "DONE", "ERROR"])
 
 
 class RunfolderInfo:

--- a/runfolder/services.py
+++ b/runfolder/services.py
@@ -4,42 +4,7 @@ import logging
 from runfolder import __version__ as version
 
 from arteria.web.state import State
-
-
-
-class Enum(set):
-    """
-    Defines an enumeration which values are a string representation of the
-    specified attribute, i.e. EnumInstance.VAL1 == "VAL1"
-
-    Usage: EnumInstance = Enum(["VAL1", "VAL2"])
-
-    print EnumInstance.VAL1
-    > "VAL1"
-
-    if "VAL3" not in EnumInstance:
-        raise ...
-    """
-    def __getattr__(self, name):
-        if name.lower() in self or name.upper() in self:
-            return name
-        raise AttributeError
-
-    def __setattr__(self, key, value):
-        raise NotImplementedError("Values cannot be set directly")
-
-"""
-NONE: Not ready for processing or invalid
-READY: Ready for processing
-PENDING: This runfolder has been handed to some other service, and is awaiting having it's status set.
-         It will wait X number of minutes before becoming available again.
-STARTED: Started processing the runfolder
-DONE: Done processing the runfolder
-ERROR: Started processing the runfolder but there was an error
-"""
-RunfolderState = Enum([State.NONE, State.READY, State.PENDING, State.STARTED, State.DONE, State.ERROR])
-
-
+from arteria.web.state import validate_state
 
 class RunfolderInfo:
     """
@@ -197,15 +162,9 @@ class RunfolderService:
         return state
 
     @staticmethod
-    def validate_state(state):
-        """Raises InvalidRunfolderState if the state is not known"""
-        if state not in RunfolderState:
-            raise InvalidRunfolderState("The state '{}' is not valid".format(state))
-
-    @staticmethod
     def set_runfolder_state(runfolder, state):
         """Sets the state of a runfolder"""
-        RunfolderService.validate_state(state)
+        validate_state(state)
         arteria_dir = os.path.join(runfolder, ".arteria")
         state_file = os.path.join(arteria_dir, "state")
         if not os.path.exists(arteria_dir):
@@ -251,7 +210,7 @@ class RunfolderService:
         """
         runfolders = self._enumerate_runfolders()
         if state:
-            RunfolderService.validate_state(state)
+            validate_state(state)
             return (runfolder for runfolder in runfolders if runfolder.state == state)
         else:
             return runfolders

--- a/runfolder_tests/integration/rest_tests.py
+++ b/runfolder_tests/integration/rest_tests.py
@@ -1,12 +1,14 @@
 import unittest
 import time
-from arteria.testhelpers import TestFunctionDelta, BaseRestTest
 import os
 import logging
 import requests
 import jsonpickle
 import mock
 import shutil
+
+from arteria.testhelpers import TestFunctionDelta, BaseRestTest
+from arteria.web.state import State
 
 
 log = logging.getLogger(__name__)
@@ -103,7 +105,7 @@ class RestApiTestCase(BaseRestTest):
         path = self._create_ready_runfolder()
         self.assertTrue(self._exists(path))
         # Mark the folder as processing
-        self.post("./runfolders/path{}".format(path), {"state": "STARTED"}, expect=200)
+        self.post("./runfolders/path{}".format(path), {"state": State.STARTED}, expect=200)
         # Ensure that the folder is not listed anymore:
         self.assertFalse(self._exists(path))
         # Remove the path created, so it does not interfere with other tests
@@ -122,7 +124,7 @@ class RestApiTestCase(BaseRestTest):
         response = self.get("./runfolders/pickup", expect=200)
         response_json = jsonpickle.loads(response.text)
         self.assertEqual(response_json["path"], path)
-        self.assertEqual(response_json["state"], "PENDING")
+        self.assertEqual(response_json["state"], State.PENDING)
         # Remove the path created, so it does not interfere with other tests
         shutil.rmtree(path)
 
@@ -133,7 +135,7 @@ class RestApiTestCase(BaseRestTest):
         response = self.get("./runfolders/next", expect=200)
         response_json = jsonpickle.loads(response.text)
         self.assertEqual(response_json["path"], path)
-        self.assertEqual(response_json["state"], "READY")
+        self.assertEqual(response_json["state"], State.READY)
         # Remove the path created, so it does not interfere with other tests
         shutil.rmtree(path)
 

--- a/runfolder_tests/integration/rest_tests.py
+++ b/runfolder_tests/integration/rest_tests.py
@@ -6,6 +6,8 @@ import logging
 import requests
 import jsonpickle
 import mock
+import shutil
+
 
 log = logging.getLogger(__name__)
 
@@ -85,6 +87,9 @@ class RestApiTestCase(BaseRestTest):
         matching = [runfolder for runfolder in runfolders if runfolder["path"] == path]
         self.assertEqual(len(matching), 1)
 
+        # Remove the path created, so it does not interfere with other tests
+        shutil.rmtree(path)
+
         # TODO: Change state to "processing" and ensure it doesn't show up in /runfolders
         self.messages_logged.assert_changed_by_total(2)
 
@@ -101,11 +106,36 @@ class RestApiTestCase(BaseRestTest):
         self.post("./runfolders/path{}".format(path), {"state": "STARTED"}, expect=200)
         # Ensure that the folder is not listed anymore:
         self.assertFalse(self._exists(path))
+        # Remove the path created, so it does not interfere with other tests
+        shutil.rmtree(path)
 
     def test_invalid_state_is_not_accepted(self):
         path = self._create_ready_runfolder()
         self.assertTrue(self._exists(path))
         self.post("./runfolders/path{}".format(path), {"state": "NOT-AVAILABLE"}, expect=400)
+        # Remove the path created, so it does not interfere with other tests
+        shutil.rmtree(path)
+
+    def test_pickup_runfolder(self):
+        path = self._create_ready_runfolder()
+        self.assertTrue(self._exists(path))
+        response = self.get("./runfolders/pickup", expect=200)
+        response_json = jsonpickle.loads(response.text)
+        self.assertEqual(response_json["path"], path)
+        self.assertEqual(response_json["state"], "PENDING")
+        # Remove the path created, so it does not interfere with other tests
+        shutil.rmtree(path)
+
+
+    def test_next_runfolder(self):
+        path = self._create_ready_runfolder()
+        self.assertTrue(self._exists(path))
+        response = self.get("./runfolders/next", expect=200)
+        response_json = jsonpickle.loads(response.text)
+        self.assertEqual(response_json["path"], path)
+        self.assertEqual(response_json["state"], "READY")
+        # Remove the path created, so it does not interfere with other tests
+        shutil.rmtree(path)
 
     def _exists(self, path):
         resp = self.get("./runfolders")

--- a/runfolder_tests/unit/runfolder_tests.py
+++ b/runfolder_tests/unit/runfolder_tests.py
@@ -34,8 +34,8 @@ class RunfolderServiceTestCase(unittest.TestCase):
         self.assertEqual(len(runfolders), 2)
 
         runfolders_str = sorted([str(runfolder) for runfolder in runfolders])
-        expected = ["READY: /data/testarteria1/mon1/runfolder001@localhost",
-                    "READY: /data/testarteria1/mon2/runfolder001@localhost"]
+        expected = ["ready: /data/testarteria1/mon1/runfolder001@localhost",
+                    "ready: /data/testarteria1/mon2/runfolder001@localhost"]
         self.assertEqual(runfolders_str, expected)
 
     def test_next_runfolder(self):
@@ -54,7 +54,7 @@ class RunfolderServiceTestCase(unittest.TestCase):
 
         # Test
         runfolder = runfolder_svc.next_runfolder()
-        expected = "READY: /data/testarteria1/mon1/runfolder001@localhost"
+        expected = "ready: /data/testarteria1/mon1/runfolder001@localhost"
         self.assertEqual(str(runfolder), expected)
 
     def test_runfolder_state_cant_be_set(self):

--- a/runfolder_tests/unit/runfolder_tests.py
+++ b/runfolder_tests/unit/runfolder_tests.py
@@ -1,6 +1,10 @@
 import unittest
 import logging
-from runfolder.services import RunfolderService, RunfolderState
+
+from arteria.web.state import State
+
+from runfolder.services import RunfolderService
+
 
 logger = logging.getLogger(__name__)
 
@@ -56,11 +60,6 @@ class RunfolderServiceTestCase(unittest.TestCase):
         runfolder = runfolder_svc.next_runfolder()
         expected = "ready: /data/testarteria1/mon1/runfolder001@localhost"
         self.assertEqual(str(runfolder), expected)
-
-    def test_runfolder_state_cant_be_set(self):
-        def assign_by_accident():
-            RunfolderState.READY = "by accident"
-        self.assertRaises(NotImplementedError, assign_by_accident)
 
     def test_monitored_directory_validates(self):
         configuration_svc = dict()


### PR DESCRIPTION
Adds a new route called `pickup` this will mark the runfolder as `PENDING` once it's been picked up by the client. This means we will get rid of the trouble in arteria where things are started multiple times - causing the system to go bananas.

@withrocks would you like to have a look.

I'd also like to fix the integration tests before this is merged. But I thought perhaps you can look at the feature implementation first?
