### PR TITLE
Make it possible to configure name of complete file

### DIFF
--- a/config/app.config
+++ b/config/app.config
@@ -9,3 +9,12 @@ monitored_directories:
 # also enables adding the runfolder-ready marker through the API.
 can_create_runfolder: False
 
+# A Illumina machine will write a RTAcompete.txt file when it has
+# finished the sequencing process. But when a user manually moves
+# the runfolder to the processing directory one can not guaranty
+# that all files have been moved when the RTAComplete.tx exist in
+# the new directory. The completed_marker_file can be changed to
+# another file, a file which for example will signal that the
+# transfer process has completed.
+completed_marker_files:
+    - RTAComplete.txt

--- a/runfolder/services.py
+++ b/runfolder/services.py
@@ -149,16 +149,21 @@ class RunfolderService:
         """
         Returns the state of a runfolder. The possible states are defined in
         State
-
         If the file .arteria/state exists, it will determine the state. If it doesn't
         exist, the existence of the marker file RTAComplete.txt determines the state.
         """
+        completed_marker_files = self._configuration_svc["completed_marker_files"]
         state = self._get_runfolder_state_from_state_file(runfolder)
         if state == State.NONE:
-            completed_marker = os.path.join(runfolder, "RTAComplete.txt")
-            ready = self._file_exists(completed_marker)
-            if ready:
-                state = State.READY
+            if (completed_marker_files is not None) and (type(completed_marker_files) is not list):
+                raise ConfigurationError("completed_marker_files must be a list")
+
+            for marker_file in completed_marker_files:
+                completed_marker = os.path.join(runfolder, marker_file)
+                ready = self._file_exists(completed_marker)
+                if ready:
+                    state = State.READY
+                    break
         return state
 
     @staticmethod

--- a/runfolder_tests/integration/config/app.config
+++ b/runfolder_tests/integration/config/app.config
@@ -2,5 +2,8 @@
 monitored_directories:
     - ./runfolders
 
+completed_marker_files:
+    - RTAComplete.txt
+
 can_create_runfolder: True
 

--- a/runfolder_tests/unit/runfolder_tests.py
+++ b/runfolder_tests/unit/runfolder_tests.py
@@ -24,6 +24,9 @@ class RunfolderServiceTestCase(unittest.TestCase):
             "monitored_directories": [
                 "/data/testarteria1/mon1",
                 "/data/testarteria1/mon2"
+            ],
+            "completed_marker_files": [
+                "RTAComplete.txt"
             ]
         }
         runfolder_svc = RunfolderService(configuration_svc, logger)
@@ -47,6 +50,9 @@ class RunfolderServiceTestCase(unittest.TestCase):
         configuration_svc = {
             "monitored_directories": [
                 "/data/testarteria1/mon1"
+            ],
+            "completed_marker_files": [
+                "RTAComplete.txt"
             ]
         }
 


### PR DESCRIPTION
This change makes it possible to specify which file/files to look for when deciding if a runfolder is READY, only one of the files need to be present.