### PR TITLE
Make it possible to configure name of complete file, single file version

### DIFF
--- a/config/app.config
+++ b/config/app.config
@@ -9,3 +9,11 @@ monitored_directories:
 # also enables adding the runfolder-ready marker through the API.
 can_create_runfolder: False
 
+# A Illumina machine will write a RTAcompete.txt file when it has
+# finished the sequencing process. But when a user manually moves
+# the runfolder to the processing directory one can not guaranty
+# that all files have been moved when the RTAComplete.tx exist in
+# the new directory. The completed_marker_file can be changed to
+# another file, a file which for example will signal that the
+# transfer process has completed.
+completed_marker_file: TransferComplete.txt

--- a/runfolder/services.py
+++ b/runfolder/services.py
@@ -153,9 +153,12 @@ class RunfolderService:
         If the file .arteria/state exists, it will determine the state. If it doesn't
         exist, the existence of the marker file RTAComplete.txt determines the state.
         """
+        completed_marker_file = self._configuration_svc["completed_marker_file"]
         state = self._get_runfolder_state_from_state_file(runfolder)
         if state == State.NONE:
-            completed_marker = os.path.join(runfolder, "RTAComplete.txt")
+            if completed_marker_file is None:
+                raise ConfigurationError("completed_marker_file must be set")
+            completed_marker = os.path.join(runfolder, completed_marker_file)
             ready = self._file_exists(completed_marker)
             if ready:
                 state = State.READY

--- a/runfolder_tests/integration/config/app.config
+++ b/runfolder_tests/integration/config/app.config
@@ -4,3 +4,5 @@ monitored_directories:
 
 can_create_runfolder: True
 
+completed_marker_file: RTAComplete.txt
+

--- a/runfolder_tests/unit/runfolder_tests.py
+++ b/runfolder_tests/unit/runfolder_tests.py
@@ -24,7 +24,8 @@ class RunfolderServiceTestCase(unittest.TestCase):
             "monitored_directories": [
                 "/data/testarteria1/mon1",
                 "/data/testarteria1/mon2"
-            ]
+            ],
+            "completed_marker_files": "RTAComplete.txt"
         }
         runfolder_svc = RunfolderService(configuration_svc, logger)
 
@@ -47,7 +48,8 @@ class RunfolderServiceTestCase(unittest.TestCase):
         configuration_svc = {
             "monitored_directories": [
                 "/data/testarteria1/mon1"
-            ]
+            ],
+            "completed_marker_files": "RTAComplete.txt"
         }
 
         # Since keys in configuration_svc can be directly indexed, we can mock it with a dict:

--- a/runfolder_tests/unit/runfolder_tests.py
+++ b/runfolder_tests/unit/runfolder_tests.py
@@ -25,7 +25,7 @@ class RunfolderServiceTestCase(unittest.TestCase):
                 "/data/testarteria1/mon1",
                 "/data/testarteria1/mon2"
             ],
-            "completed_marker_files": "RTAComplete.txt"
+            "completed_marker_file": "RTAComplete.txt"
         }
         runfolder_svc = RunfolderService(configuration_svc, logger)
 
@@ -49,7 +49,7 @@ class RunfolderServiceTestCase(unittest.TestCase):
             "monitored_directories": [
                 "/data/testarteria1/mon1"
             ],
-            "completed_marker_files": "RTAComplete.txt"
+            "completed_marker_file": "RTAComplete.txt"
         }
 
         # Since keys in configuration_svc can be directly indexed, we can mock it with a dict:


### PR DESCRIPTION
This change makes it possible to specify which file to look for when deciding if a runfolder is READY.