### PR TITLE
Sequencing complete detection

### DIFF
--- a/config/app.config
+++ b/config/app.config
@@ -16,7 +16,7 @@ can_create_runfolder: False
 # the new directory. The completed_marker_file can be changed to
 # another file, a file which for example will signal that the
 # transfer process has completed.
-completed_marker_files:
+completed_marker_file:
     - RTAComplete.txt
     - SequencingComplete.txt
 

--- a/config/app.config
+++ b/config/app.config
@@ -26,4 +26,4 @@ completed_marker_file:
 # defined here. The modification time of each of the files specified
 # in completed_marker_files has to be longer ago that the amount of
 # minutes specified here
-completed_marker_grace_minutes: 15
+completed_marker_grace_minutes: 0

--- a/config/app.config
+++ b/config/app.config
@@ -9,12 +9,21 @@ monitored_directories:
 # also enables adding the runfolder-ready marker through the API.
 can_create_runfolder: False
 
-# A Illumina machine will write a RTAComplete.txt file when it has
+# An Illumina machine will write a RTAComplete.txt file when it has
 # finished the sequencing process. But when a user manually moves
 # the runfolder to the processing directory one can not guaranty
 # that all files have been moved when the RTAComplete.tx exist in
 # the new directory. The completed_marker_file can be changed to
 # another file, a file which for example will signal that the
 # transfer process has completed.
-completed_marker_file: RTAComplete.txt
+completed_marker_files:
+    - RTAComplete.txt
+    - SequencingComplete.txt
 
+# It seems that sometimes the completed_marker_files are not a
+# reliable indicator that nothing more will be modified or written
+# in the sequencing runfolder. Therefore a grace period can be
+# defined here. The modification time of each of the files specified
+# in completed_marker_files has to be longer ago that the amount of
+# minutes specified here
+completed_marker_grace_minutes: 15

--- a/runfolder/services.py
+++ b/runfolder/services.py
@@ -162,8 +162,19 @@ class RunfolderService:
         If the file .arteria/state exists, it will determine the state. If it doesn't
         exist, the existence of the marker file RTAComplete.txt determines the state.
         """
-        completed_marker_files = self._configuration_svc["completed_marker_files"]
-        completed_grace_minutes = self._configuration_svc["completed_marker_grace_minutes"]
+        completed_marker_files = None
+        try:
+            completed_marker_files = self._configuration_svc["completed_marker_file"]
+            if isinstance(completed_marker_files, basestring):
+                completed_marker_files = [completed_marker_files]
+        except KeyError:
+            pass
+        completed_grace_minutes = None
+        try:
+            completed_grace_minutes = self._configuration_svc["completed_marker_grace_minutes"]
+        except KeyError:
+            pass
+
         if completed_grace_minutes is None:
             completed_grace_minutes = 0
         state = self._get_runfolder_state_from_state_file(runfolder)

--- a/runfolder/services.py
+++ b/runfolder/services.py
@@ -165,7 +165,7 @@ class RunfolderService:
         completed_marker_files = None
         try:
             completed_marker_files = self._configuration_svc["completed_marker_file"]
-            if isinstance(completed_marker_files, basestring):
+            if isinstance(completed_marker_files, str):
                 completed_marker_files = [completed_marker_files]
         except KeyError:
             raise ConfigurationError("completed_marker_file must be set")

--- a/runfolder/services.py
+++ b/runfolder/services.py
@@ -49,6 +49,7 @@ class RunfolderService:
     def _file_exists(path):
         return os.path.isfile(path)
 
+    @staticmethod
     def _file_exists_and_is_older_than(path, minutes):
         if not os.path.isfile(path):
             return False

--- a/runfolder/services.py
+++ b/runfolder/services.py
@@ -168,7 +168,7 @@ class RunfolderService:
             if isinstance(completed_marker_files, basestring):
                 completed_marker_files = [completed_marker_files]
         except KeyError:
-            pass
+            raise ConfigurationError("completed_marker_file must be set")
         completed_grace_minutes = None
         try:
             completed_grace_minutes = self._configuration_svc["completed_marker_grace_minutes"]
@@ -179,8 +179,6 @@ class RunfolderService:
             completed_grace_minutes = 0
         state = self._get_runfolder_state_from_state_file(runfolder)
         if state == State.NONE:
-            if completed_marker_files is None:
-                raise ConfigurationError("completed_marker_file must be set")
             ready = True
             for marker_file in completed_marker_files:
                 completed_marker = os.path.join(runfolder, marker_file)

--- a/runfolder_tests/unit/runfolder_tests.py
+++ b/runfolder_tests/unit/runfolder_tests.py
@@ -18,6 +18,9 @@ class RunfolderServiceTestCase(unittest.TestCase):
         else:
             raise Exception("Unexpected path")
 
+    def _is_older_wrapper(self, path, age):
+        return self._valid_runfolder(path)
+
     def test_list_available_runfolders(self):
         # Setup
         configuration_svc = {
@@ -30,6 +33,7 @@ class RunfolderServiceTestCase(unittest.TestCase):
         runfolder_svc = RunfolderService(configuration_svc, logger)
 
         runfolder_svc._file_exists = self._valid_runfolder
+        runfolder_svc._file_exists_and_is_older_than = self._is_older_wrapper
         runfolder_svc._subdirectories = lambda path: ["runfolder001"]
         runfolder_svc._host = lambda: "localhost"
 
@@ -55,6 +59,7 @@ class RunfolderServiceTestCase(unittest.TestCase):
         # Since keys in configuration_svc can be directly indexed, we can mock it with a dict:
         runfolder_svc = RunfolderService(configuration_svc, logger)
         runfolder_svc._file_exists = self._valid_runfolder
+        runfolder_svc._file_exists_and_is_older_than = self._is_older_wrapper
         runfolder_svc._subdirectories = lambda path: ["runfolder001"]
         runfolder_svc._host = lambda: "localhost"
 


### PR DESCRIPTION
**What problems does this PR solve?**
`RTAComplete.txt` is not always the last file written to in a runfolder. This didn't use to be a problem, because by the time a run is started, everything had been written. But now, when we move a runfolder to a non-networkaccessible location once it is supposedly 'finished', this can lead to files being left behind due to them being written after the move.
This PR attempts to mitigate that with two measures:
 * use a configurable set of files to detect finishedness
 * wait a configurable amount of time after these files have been written, before marking a runfolder as 'READY'

**How has the changes been tested?**
The changes have been tested on vagrant machines

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
