### PR TITLE
Do not raise error when there is no runfolder

### DIFF
--- a/runfolder/handlers.py
+++ b/runfolder/handlers.py
@@ -66,7 +66,10 @@ class NextAvailableRunfolderHandler(BaseRunfolderHandler):
         runfolder_info = self.runfolder_svc.next_runfolder()
         if runfolder_info:
             self.append_runfolder_link(runfolder_info)
-        self.write_object(runfolder_info)
+            self.write_object(runfolder_info)
+        else:
+            self.set_status(204, reason="No ready runfolder available.")
+            self.write(dict())
 
 
 class PickupAvailableRunfolderHandler(BaseRunfolderHandler):

--- a/runfolder_tests/integration/rest_tests.py
+++ b/runfolder_tests/integration/rest_tests.py
@@ -139,6 +139,10 @@ class RestApiTestCase(BaseRestTest):
         # Remove the path created, so it does not interfere with other tests
         shutil.rmtree(path)
 
+    def test_call_next_without_ready_runfolder(self):
+        # Status code 204 is no content.
+        response = self.get("./runfolders/next", expect=204)
+
     def _exists(self, path):
         resp = self.get("./runfolders")
         runfolders = resp.body_obj["runfolders"]


### PR DESCRIPTION
**What problems does this PR solve?**
When we called the `/next` endpoint we would get an error if there was no runfolder available. This is not an error.

**How has the changes been tested?**
I wrote a new integration test for this.

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
