### PR TITLE
Metadata in runfolder info

### DIFF
--- a/requirements/prod
+++ b/requirements/prod
@@ -2,4 +2,4 @@ git+https://github.com/arteria-project/arteria-core.git@v1.1.0#egg=arteria-core
 jsonpickle==0.9.2
 tornado==4.2.1
 PyYAML==3.11
-xmltodict
+xmltodict==0.11.0

--- a/requirements/prod
+++ b/requirements/prod
@@ -2,3 +2,4 @@ git+https://github.com/arteria-project/arteria-core.git@v1.1.0#egg=arteria-core
 jsonpickle==0.9.2
 tornado==4.2.1
 PyYAML==3.11
+xmltodict

--- a/runfolder/services.py
+++ b/runfolder/services.py
@@ -2,7 +2,6 @@ import os.path
 import socket
 import logging
 import time
-import json
 import xmltodict
 from runfolder import __version__ as version
 

--- a/runfolder/services.py
+++ b/runfolder/services.py
@@ -26,10 +26,7 @@ class RunfolderInfo:
         self.path = path
         self.state = state
         self.service_version = version
-        if metadata:
-            self.metadata = metadata
-        else:
-            self.metadata = {}
+        self.metadata = metadata
 
     def __repr__(self):
         return "{0}: {1}@{2}".format(self.state, self.path, self.host)
@@ -164,7 +161,7 @@ class RunfolderService:
         if not self._dir_exists(path):
             raise DirectoryDoesNotExist("Directory does not exist: '{0}'".format(path))
         info = RunfolderInfo(self._host(), path, self.get_runfolder_state(path),
-                                self.get_metadata(path))
+                             self.get_metadata(path))
         return info
 
     def _get_runfolder_state_from_state_file(self, runfolder):
@@ -303,10 +300,10 @@ class RunfolderService:
             # Reagent kit barcode is not available for all run types,
             # it is therefore expected to not be found in all cases
             self._logger.debug("Reagent kit barcode not found")
-            barcode = None
+            return None
         except TypeError:
             self._logger.debug("[Rr]unParameters.xml not found")
-            barcode = None
+            return None
         return barcode
 
     def get_library_tube_barcode(self, path, run_parameters):
@@ -316,10 +313,10 @@ class RunfolderService:
             # Library tube barcode is not available for all run types,
             # it is therefore expected to not be found in all cases
             self._logger.debug("Library tube barcode not found")
-            barcode = None
+            return None
         except TypeError:
             self._logger.debug("[Rr]unParameters.xml not found")
-            barcode = None
+            return None
         return barcode
 
     def read_run_parameters(self, path):

--- a/runfolder/services.py
+++ b/runfolder/services.py
@@ -103,6 +103,20 @@ class RunfolderService:
         os.makedirs(path)
         self._logger.info(
             "Created a runfolder at {0} - intended for tests only".format(path))
+        runparameters_path = os.path.join(path, "runParameters.xml")
+        if os.path.isfile(runparameters_path):
+            raise CannotOverrideFile("runParameters.xml already exists at {0}".format(runparameters_path))
+
+        with open(runparameters_path, 'w') as file:
+            file.write('<?xml version="1.0"?>')
+            file.write('<RunParameters>')
+            file.write('  <ReagentKitBarcode>AB1234567-123V1</ReagentKitBarcode>')
+            file.write('</RunParameters>')
+            file.close()
+
+        self._logger.info(
+            "Added 'runParameters.xml' to '{0}' - intended for tests only".format(runparameters_path))
+
 
     def add_sequencing_finished_marker(self, path):
         """
@@ -252,7 +266,7 @@ class RunfolderService:
                 directory = os.path.join(monitored_root, subdir)
                 self._logger.debug("Found potential runfolder {0}".format(directory))
                 state = self.get_runfolder_state(directory)
-                info = RunfolderInfo(self._host(), directory, state)
+                info = RunfolderInfo(self._host(), directory, state, self.get_reagent_kit_barcode(directory))
                 yield info
 
     def _requires_enabled(self, config_key):

--- a/runfolder/services.py
+++ b/runfolder/services.py
@@ -106,12 +106,19 @@ class RunfolderService:
         if os.path.isfile(runparameters_path):
             raise CannotOverrideFile("runParameters.xml already exists at {0}".format(runparameters_path))
 
-        with open(runparameters_path, 'w') as file:
-            file.write('<?xml version="1.0"?>')
-            file.write('<RunParameters>')
-            file.write('  <ReagentKitBarcode>AB1234567-123V1</ReagentKitBarcode>')
-            file.write('</RunParameters>')
-            file.close()
+        runparameters_dict = {
+                'RunParameters': {
+                        'ReagentKitBarcode': 'AB1234567-123V1',
+                        'RfidsInfo': {
+                                'LibraryTubeSerialBarcode': 'NV0012345-LIB'
+                            }
+                    }
+            }
+
+        output_xml = xmltodict.unparse(runparameters_dict, pretty=True)
+
+        with open(runparameters_path, 'a') as f:
+            f.write(output_xml)
 
         self._logger.info(
             "Added 'runParameters.xml' to '{0}' - intended for tests only".format(runparameters_path))

--- a/runfolder_tests/integration/rest_tests.py
+++ b/runfolder_tests/integration/rest_tests.py
@@ -139,12 +139,13 @@ class RestApiTestCase(BaseRestTest):
         # Remove the path created, so it does not interfere with other tests
         shutil.rmtree(path)
 
-    def test_reagent_kit_barcode_in_runfolder_info(self):
+    def test_metadata_in_runfolder_info(self):
         path = self._create_ready_runfolder()
         self.assertTrue(self._exists(path))
         response = self.get("./runfolders/path{}".format(path), expect=200)
         response_json = jsonpickle.loads(response.text)
-        self.assertEqual(response_json["reagent_kit_barcode"], 'AB1234567-123V1')
+        self.assertEqual(response_json["metadata"]["reagent_kit_barcode"], 'AB1234567-123V1')
+        self.assertEqual(response_json["metadata"]["library_tube_barcode"], 'NV0012345-LIB')
         # Remove the path created, so it does not interfere with other tests
         shutil.rmtree(path)
 

--- a/runfolder_tests/integration/rest_tests.py
+++ b/runfolder_tests/integration/rest_tests.py
@@ -139,6 +139,15 @@ class RestApiTestCase(BaseRestTest):
         # Remove the path created, so it does not interfere with other tests
         shutil.rmtree(path)
 
+    def test_reagent_kit_barcode_in_runfolder_info(self):
+        path = self._create_ready_runfolder()
+        self.assertTrue(self._exists(path))
+        response = self.get("./runfolders/path{}".format(path), expect=200)
+        response_json = jsonpickle.loads(response.text)
+        self.assertEqual(response_json["reagent_kit_barcode"], 'AB1234567-123V1')
+        # Remove the path created, so it does not interfere with other tests
+        shutil.rmtree(path)
+
     def test_call_next_without_ready_runfolder(self):
         # Status code 204 is no content.
         response = self.get("./runfolders/next", expect=204)

--- a/runfolder_tests/unit/runfolder_tests.py
+++ b/runfolder_tests/unit/runfolder_tests.py
@@ -45,7 +45,7 @@ class RunfolderServiceTestCase(unittest.TestCase):
 
         runfolders_str = sorted([str(runfolder) for runfolder in runfolders])
         expected = ["ready: /data/testarteria1/mon1/runfolder001@localhost",
-                "ready: /data/testarteria1/mon2/runfolder001@localhost"]
+                    "ready: /data/testarteria1/mon2/runfolder001@localhost"]
         self.assertEqual(runfolders_str, expected)
 
     def test_next_runfolder(self):


### PR DESCRIPTION
**What problems does this PR solve?**
This PR adds reagent kit barcode as an instance attribute to the RunfolderInfo class. At SNP&SEQ technology platform this barcode is sometimes used as a run identifier instead of the flowcell ID, so that's why we're interested in it. This information is read from [rR]unParameters.xml, which is assumed to be located in the runfolder.

Not all run types include this information and in that case the attribute will simply be `null`. 

**How has the changes been tested?**
In addition to automatic tests, I've tested the service locally on a tiny-test-data flowcell (https://github.com/roryk/tiny-test-data/tree/master/flowcell)

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
