### PR TITLE
DEVELOP-1099 - use custom completed marker files for different instruments

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,19 @@ This means that the client (e.g. a workflow) is responsible for updating the sta
 
 **Try it out:**
 
-Install using pip:
+    # create venv
+    virtualenv -p python2.7 venv/   
 
-    pip install -r requirements/dev . # possible add -e if you're in development mode.
+    # activate venv
+    source venv/bin/activate
+
+    # install dependencies
+    pip install -e . -r ./requirements/dev
 
 Open up the `config/app.config` and specify the root directories that you want to monitor for runfolders. Then run:
 
-    runfolder-ws --port 9999 --configroot config/
+    # start the dev server
+    python server.py --debug --port=9999 --configroot='./config'
 
 This will star the runfolder service on port 9999, and the api dock will be available under `localhost:9999/api`.
 Try curl-ing to see what you can do with it:
@@ -47,7 +53,3 @@ Alternatively, you can run the same script against a remote server, specifying t
 
 Unit tests can be run with
     nosetests ./runfolder_tests/unit
-
-**Install in production**
-One way to install this as a daemon in a production environment
-can be seen at https://github.com/arteria-project/arteria-provisioning

--- a/config/app.config
+++ b/config/app.config
@@ -9,17 +9,6 @@ monitored_directories:
 # also enables adding the runfolder-ready marker through the API.
 can_create_runfolder: False
 
-# An Illumina machine will write a RTAComplete.txt file when it has
-# finished the sequencing process. But when a user manually moves
-# the runfolder to the processing directory one can not guaranty
-# that all files have been moved when the RTAComplete.tx exist in
-# the new directory. The completed_marker_file can be changed to
-# another file, a file which for example will signal that the
-# transfer process has completed.
-completed_marker_file:
-    - RTAComplete.txt
-    - SequencingComplete.txt
-
 # It seems that sometimes the completed_marker_files are not a
 # reliable indicator that nothing more will be modified or written
 # in the sequencing runfolder. Therefore a grace period can be

--- a/runfolder/lib/instrument.py
+++ b/runfolder/lib/instrument.py
@@ -1,0 +1,81 @@
+# Typically, an Illumina machine writes a RTAComplete.txt file when it has
+# finished the sequencing process. However, some instruments may use another
+# completed_marker_file, for instance one that indicates that files have
+# been transferred.
+
+import re
+
+
+class InstrumentFactory():
+    @staticmethod
+    def get_id(run_parameters):
+        run_parameters = run_parameters.get('RunParameters', None)
+
+        # HiSeq / HiSeq X instrument stored in Setup#ScannerID
+        val = run_parameters.get('Setup', {}).get('ScannerID')
+        if val:
+            return val
+
+        # Other instrument id's are at the top level of RunParameters
+        for key in ["InstrumentName", "InstrumentId", "ScannerID"]:
+            if key in run_parameters.viewkeys():
+                return run_parameters.get(key)
+
+    @staticmethod
+    def get_instrument(run_parameters):
+        if not run_parameters:
+            return Instrument()
+
+        instrument_id = InstrumentFactory.get_id(run_parameters)
+
+        if not instrument_id:
+            return Instrument()
+
+        if re.search(NovaSeq.ID_PATTERN, instrument_id):
+            return NovaSeq()
+        if re.search(ISeq.ID_PATTERN, instrument_id):
+            return ISeq()
+        if re.search(MiSeq.ID_PATTERN, instrument_id):
+            return MiSeq()
+        if re.search(HiSeq.ID_PATTERN, instrument_id):
+            return HiSeq()
+        if re.search(HiSeqX.ID_PATTERN, instrument_id):
+            return HiSeqX()
+        return Instrument()
+
+
+class Instrument():
+    COMPLETED_MARKER_FILE_RTA_COMPLETE = 'RTAComplete.txt'
+    COMPLETED_MARKER_FILE_COPY_COMPLETE = 'CopyComplete.txt'
+
+    @staticmethod
+    def completed_marker_file():
+        return Instrument.COMPLETED_MARKER_FILE_RTA_COMPLETE
+
+
+class NovaSeq(Instrument):
+    ID_PATTERN = '^A'
+
+    @staticmethod
+    def completed_marker_file():
+        return Instrument.COMPLETED_MARKER_FILE_COPY_COMPLETE
+
+
+class ISeq(Instrument):
+    ID_PATTERN = '^FS'
+
+    @staticmethod
+    def completed_marker_file():
+        return Instrument.COMPLETED_MARKER_FILE_COPY_COMPLETE
+
+
+class MiSeq(Instrument):
+    ID_PATTERN = '^M'
+
+
+class HiSeq(Instrument):
+    ID_PATTERN = '^D'
+
+
+class HiSeqX(HiSeq):
+    ID_PATTERN = '^ST-E'

--- a/runfolder_tests/unit/instrument_tests.py
+++ b/runfolder_tests/unit/instrument_tests.py
@@ -1,0 +1,75 @@
+import unittest
+import logging
+import mock
+
+
+from runfolder.lib.instrument import InstrumentFactory, Instrument
+
+
+logger = logging.getLogger(__name__)
+
+class InstrumentTestCase(unittest.TestCase):
+    def test_get_instrument_by_id(self):
+        # HiSeqX
+        instrument_attr = {
+            'Setup': {
+                'ScannerID': 'ST-E123'
+            }
+        }
+        run_parameters = {
+            'RunParameters': instrument_attr
+        }
+
+        i = InstrumentFactory.get_instrument(run_parameters)
+        self.assertEqual(i.__class__.__name__, 'HiSeqX')
+        self.assertEqual(i.completed_marker_file(), 'RTAComplete.txt')
+
+        # HiSeq
+        run_parameters['RunParameters']['Setup']['ScannerID'] = 'D999'
+        i = InstrumentFactory.get_instrument(run_parameters)
+        self.assertEqual(i.__class__.__name__, 'HiSeq')
+        self.assertEqual(i.completed_marker_file(), 'RTAComplete.txt')
+
+        # NovaSeq
+        run_parameters = {
+            'RunParameters': {
+                'InstrumentName': 'ABC'
+            }
+        }
+        i = InstrumentFactory.get_instrument(run_parameters)
+        self.assertEqual(i.__class__.__name__, 'NovaSeq')
+        self.assertEqual(i.completed_marker_file(), 'CopyComplete.txt')
+
+        # iSeq
+        run_parameters = {
+            'RunParameters': {
+                'InstrumentId': 'FS1'
+            }
+        }
+        i = InstrumentFactory.get_instrument(run_parameters)
+        self.assertEqual(i.__class__.__name__, 'ISeq')
+        self.assertEqual(i.completed_marker_file(), 'CopyComplete.txt')
+
+        # MiSeq
+        run_parameters = {
+            'RunParameters': {
+                'ScannerID': 'M1'
+            }
+        }
+        i = InstrumentFactory.get_instrument(run_parameters)
+        self.assertEqual(i.__class__.__name__, 'MiSeq')
+        self.assertEqual(i.completed_marker_file(), 'RTAComplete.txt')
+
+        # Default
+        run_parameters = {
+            'RunParameters': {
+                'ScannerID': 'foo'
+            }
+        }
+        i = InstrumentFactory.get_instrument(run_parameters)
+        self.assertEqual(i.__class__.__name__, 'Instrument')
+        self.assertEqual(i.completed_marker_file(), 'RTAComplete.txt')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/runfolder_tests/unit/runfolder_tests.py
+++ b/runfolder_tests/unit/runfolder_tests.py
@@ -28,8 +28,7 @@ class RunfolderServiceTestCase(unittest.TestCase):
             "monitored_directories": [
                 "/data/testarteria1/mon1",
                 "/data/testarteria1/mon2"
-            ],
-            "completed_marker_file": "RTAComplete.txt"
+            ]
         }
         runfolder_svc = RunfolderService(configuration_svc, logger)
 
@@ -53,8 +52,7 @@ class RunfolderServiceTestCase(unittest.TestCase):
         configuration_svc = {
             "monitored_directories": [
                 "/data/testarteria1/mon1"
-            ],
-            "completed_marker_file": "RTAComplete.txt"
+            ]
         }
 
         # Since keys in configuration_svc can be directly indexed, we can mock it with a dict:

--- a/server.py
+++ b/server.py
@@ -1,0 +1,5 @@
+from runfolder.app import start
+
+
+if __name__ == '__main__':
+    start()


### PR DESCRIPTION
**What problems does this PR solve?**
This allows us to specify alternatives to RTAComplete.txt based on instrument type. This fixes the problem whereby a runfolder is marked complete before all of the files have been copied.

Note that completed_marker_file is being removed from the config file, since currently this value is the same in all environments (it is set to RTAComplete.txt in sysman).

I've also added a dev server file and updated the README to facilitate development.

**How has the changes been tested?**
Manual testing of API plus integration and unit tests.

**Reasons for careful code review**
Ensure that fallbacks work correctly so that the default is always RTAComplete.txt unless otherwise specified.

If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
