### PR TITLE
Check if runfolder exists before attempting to set state

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,15 @@ Try curl-ing to see what you can do with it:
 
 **Running the tests**
 After install you could run the integration tests to see if everything works as expected:
+
     ./runfolder_tests/run_integration_tests.py
 
 This will by default start a local server, run the integration tests on it and then shut the server down.
 
 Alternatively, you can run the same script against a remote server, specifying the URL and the runfolder directory:
+
     ./runfolder_tests/run_integration_tests.py http://testarteria1:10800/api/1.0 /data/testartera1/runfolders
 
 Unit tests can be run with
+
     nosetests ./runfolder_tests/unit

--- a/runfolder/handlers.py
+++ b/runfolder/handlers.py
@@ -1,3 +1,4 @@
+import sys
 
 import tornado.web
 
@@ -122,6 +123,9 @@ class RunfolderHandler(BaseRunfolderHandler):
             self.runfolder_svc.set_runfolder_state(path, state)
         except InvalidArteriaStateException:
             raise tornado.web.HTTPError(400, "The state '{}' is not valid".format(state))
+        except DirectoryDoesNotExist:
+            raise tornado.web.HTTPError(404, "Runfolder '{0}' does not exist".format(path))
+
 
     @arteria.undocumented
     def put(self, path):

--- a/runfolder/services.py
+++ b/runfolder/services.py
@@ -210,12 +210,22 @@ class RunfolderService:
 
     @staticmethod
     def set_runfolder_state(runfolder, state):
-        """Sets the state of a runfolder"""
+        """
+        Sets the state of a runfolder
+
+        :raises DirectoryDoesNotExist
+        """
         validate_state(state)
         arteria_dir = os.path.join(runfolder, ".arteria")
         state_file = os.path.join(arteria_dir, "state")
+
+        if not os.path.exists(runfolder):
+            raise DirectoryDoesNotExist(
+                    "Directory does not exist: '{0}'".format(runfolder))
+
         if not os.path.exists(arteria_dir):
             os.makedirs(arteria_dir)
+
         with open(state_file, 'w') as f:
             f.write(state)
 

--- a/runfolder_tests/integration/rest_tests.py
+++ b/runfolder_tests/integration/rest_tests.py
@@ -118,6 +118,12 @@ class RestApiTestCase(BaseRestTest):
         # Remove the path created, so it does not interfere with other tests
         shutil.rmtree(path)
 
+    def test_set_state_raises_exception(self):
+        path = self._create_ready_runfolder()
+        self.assertTrue(self._exists(path))
+        shutil.rmtree(path)
+        self.post("./runfolders/path{}".format(path), {"state": State.STARTED}, expect=404)
+
     def test_pickup_runfolder(self):
         path = self._create_ready_runfolder()
         self.assertTrue(self._exists(path))


### PR DESCRIPTION
**What problems does this PR solve?**
This PR solves issue #28 by checking if a path exists before attempting to change the state of the runfolder.

Closes #28

**How has the changes been tested?**
Integration tests have been updated.

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
