### PR TITLE
DATAOPS-617:getting novaseqx library_tube_barcode

### DIFF
--- a/runfolder/services.py
+++ b/runfolder/services.py
@@ -317,10 +317,22 @@ class RunfolderService:
         try:
             barcode = run_parameters['RunParameters']['RfidsInfo']['LibraryTubeSerialBarcode']
         except KeyError:
-            # Library tube barcode is not available for all run types,
-            # it is therefore expected to not be found in all cases
-            self._logger.debug("Library tube barcode not found")
-            return None
+            try:
+                # Novaseq X Plus barcode is located in ConsumableInfo -> SerialNumber where type is SampleTube
+                consumables = run_parameters["RunParameters"]["ConsumableInfo"]["ConsumableInfo"]
+                barcode = next(
+                    (
+                        consumable["SerialNumber"]
+                        for consumable in consumables
+                        if consumable['Type'] == "SampleTube"
+                    ),
+                    None,
+                )
+            except KeyError:
+                # Library tube barcode is not available for all run types,
+                # it is therefore expected to not be found in all cases
+                self._logger.debug("Library tube barcode not found")
+                return None
         except TypeError:
             self._logger.debug("[Rr]unParameters.xml not found")
             return None

--- a/runfolder_tests/unit/runfolder_tests.py
+++ b/runfolder_tests/unit/runfolder_tests.py
@@ -110,6 +110,24 @@ class RunfolderServiceTestCase(unittest.TestCase):
         # Test
         self.assertEqual(runfolder_svc.get_library_tube_barcode('/path/to/runfolder/', runparameters_dict), 'NV0012345-LIB')
 
+    def test_get_novaseqxplus_library_tube_barcode_found(self):
+        # Setup
+        configuration_svc = dict()
+        configuration_svc["monitored_directories"] = ["/data/testarteria1/runfolders"]
+        runfolder_svc = RunfolderService(configuration_svc, logger)
+        runparameters_dict = {
+                                "RunParameters": {
+                                    "ConsumableInfo": {
+                                        "ConsumableInfo": [
+                                            {"Type": "SampleTube", "SerialNumber": "LC1037822-LC1"}
+                                        ]
+                                    }
+                                }
+                            }
+
+        # Test
+        self.assertEqual(runfolder_svc.get_library_tube_barcode('/path/to/runfolder/', runparameters_dict), 'LC1037822-LC1')
+
     def test_get_library_tube_barcode_not_found(self):
         # Setup
         configuration_svc = dict()

--- a/runfolder_tests/unit/runfolder_tests.py
+++ b/runfolder_tests/unit/runfolder_tests.py
@@ -119,6 +119,7 @@ class RunfolderServiceTestCase(unittest.TestCase):
                                 "RunParameters": {
                                     "ConsumableInfo": {
                                         "ConsumableInfo": [
+                                            {"Type": "Other", "SerialNumber": "INCORRECT123"},
                                             {"Type": "SampleTube", "SerialNumber": "LC1037822-LC1"}
                                         ]
                                     }


### PR DESCRIPTION
**What problems does this PR solve?**
The barcode information in the metadata for Novaseq X Plus is located in a different position from the usual. This code adds code to pick the barcode number from NovaSeq X plus too.

**How has the changes been tested?**
By adding a unit test with RunParameters similar to that present for NovaSeq X Plus.

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be initiated.

  - [ ] This PR contains code that could remove data
